### PR TITLE
feat: implement AppHeader component and add server-side route handler…

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -176,8 +176,8 @@ const Resources = [
       { label: "About", to: "/about" },
       { label: "Blog", to: "/blog" },
       { label: "Changelog", to: "/changelog" },
-      { label: "Members", to: "/members" },
-    ],
+      { label: "Members", to: "/members" }
+    ]
   },
   {
     title: "",
@@ -185,21 +185,21 @@ const Resources = [
       { label: "Terhubung", to: "/terhubung" },
       { label: "Karir", to: "/karir" },
       { label: "Donation", to: "/donasi" },
-    { label: "Gallery", to: "/galeri" },
-      { label: "Faq", to: "/faq" },
-    ],
+      { label: "Gallery", to: "/galeri" },
+      { label: "Faq", to: "/faq" }
+    ]
   },
   {
     title: "",
     links: [
-      { label: "Sponsor", to: "/sponsor" },
-      { label: "Marketplace", to: "/marketplace" },
-      { label: "Partner", to: "/partner" },
-      { label: "Contact Us", to: "/kontak" },
-      { label: "Community ↗", to: "/community" },
-    ],
-  },
-];
+      { label: "Sponsor", to: "https://github.com/sponsors/nlfts", target: "_blank", external: true },
+      { label: "Marketplace", to: "https://github.com/NLFTs", target: "_blank", external: true },
+      { label: "Partner", to: "/terhubung" },
+      { label: "Contact Us", to: "/terhubung" },
+      { label: "Community ↗", to: "https://discord.gg/uNc3r3ZKQx", target: "_blank", external: true }
+    ]
+  }
+]
 </script>
 
 <template>
@@ -310,9 +310,11 @@ const Resources = [
                   <ul class="space-y-2">
                     <li v-for="item in section.links" :key="item.to" class="dd-animate">
                       <HoverLink 
-                          :to="item.to" 
-                          :label="item.label" 
-                        />
+                        :to="item.to" 
+                        :label="item.label" 
+                        :target="item.target"
+                        :external="item.external"
+                      />
                     </li>
                   </ul>
                 </div>
@@ -431,6 +433,8 @@ const Resources = [
                     v-for="item in section.links"
                     :key="item.to"
                     :to="item.to"
+                    :target="item.target"
+                    :external="item.external"
                     class="flex items-center gap-2 py-1 text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
                     @click="closeMobile"
                   >

--- a/app/components/HoverLink.vue
+++ b/app/components/HoverLink.vue
@@ -1,6 +1,8 @@
 <template>
   <NuxtLink
     :to="to"
+    :target="target"
+    :external="external"
     class="text-sm text-zinc-900 dark:text-zinc-100 hover:text-primary-500 transition-colors"
     @mouseenter="startShuffle"
   >
@@ -9,7 +11,7 @@
 </template>
 
 <script setup>
-const props = defineProps(['label', 'to'])
+const props = defineProps(['label', 'to', 'target', 'external'])
 const displayText = ref(props.label)
 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%'
 

--- a/server/routes/community.ts
+++ b/server/routes/community.ts
@@ -1,0 +1,5 @@
+import { sendRedirect } from 'h3'
+
+export default defineEventHandler((event) => {
+  return sendRedirect(event, 'https://discord.gg/uNc3r3ZKQx', 302)
+})

--- a/server/routes/kontak.ts
+++ b/server/routes/kontak.ts
@@ -1,0 +1,5 @@
+import { sendRedirect } from 'h3'
+
+export default defineEventHandler((event) => {
+  return sendRedirect(event, '/terhubung', 302)
+})

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -1,0 +1,5 @@
+import { sendRedirect } from 'h3'
+
+export default defineEventHandler((event) => {
+  return sendRedirect(event, 'https://github.com/NLFTs', 302)
+})

--- a/server/routes/partner.ts
+++ b/server/routes/partner.ts
@@ -1,0 +1,5 @@
+import { sendRedirect } from 'h3'
+
+export default defineEventHandler((event) => {
+  return sendRedirect(event, '/terhubung', 302)
+})

--- a/server/routes/sponsor.ts
+++ b/server/routes/sponsor.ts
@@ -1,0 +1,5 @@
+import { sendRedirect } from 'h3'
+
+export default defineEventHandler((event) => {
+  return sendRedirect(event, 'https://github.com/sponsors/nlfts', 302)
+})


### PR DESCRIPTION
修复导航链接导致的 404 Payload 与 JSON 预加载错误

- 修复 Header 导航链接指向不存在页面导致的 404 Payload 问题。
- 为 HoverLink 组件新增 `target` 与 `external` 属性支持。
- 更新导航链接：
  - Sponsor → GitHub Sponsors（外部链接）
  - Marketplace → GitHub Organization（外部链接）
  - Partner → /terhubung
  - Contact Us → /terhubung
  - Community → Discord 邀请链接（外部链接）
- 避免 NuxtLink 对外部链接执行 `_payload.json` 预加载，从而消除 `SyntaxError: Unexpected token '<'`。
- 新增 Nitro 服务端重定向：
  - /sponsor → GitHub Sponsors
  - /marketplace → GitHub Organization
  - /partner → /terhubung
  - /kontak → /terhubung
  - /community → Discord
- 重新执行静态生成（pnpm generate），Prerender 全部通过，无任何错误。