### PR TITLE
feat: implement index page layout and blog section with GSAP animations

### DIFF
--- a/app/components/BlogSection.vue
+++ b/app/components/BlogSection.vue
@@ -55,10 +55,10 @@ onMounted(async () => {
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-0 border-t border-l border-zinc-200 dark:border-zinc-800">
-      <div 
+    <div 
         v-for="(post, index) in posts" 
         :key="index"
-        class="border-r border-b border-zinc-200 dark:border-zinc-800 p-8 hover:bg-zinc-50 dark:hover:bg-zinc-900/50 transition-colors group"
+        class="blog-reveal border-r border-b border-zinc-200 dark:border-zinc-800 p-8 hover:bg-zinc-50 dark:hover:bg-zinc-900/50 transition-colors group"
       >
         <NuxtLink :to="post.path" class="flex flex-col h-full justify-between">
           <div class="space-y-6">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -190,17 +190,21 @@ onMounted(() => {
     { y: 0, opacity: 1, duration: 0.8 }
   )
 
-  tl.fromTo(heroTitleRef.value, 
-    { y: 20, opacity: 0 },
-    { y: 0, opacity: 1 },
-    '-=0.6'
-  )
+  if (heroTitleRef.value) {
+    tl.fromTo(heroTitleRef.value, 
+      { y: 20, opacity: 0 },
+      { y: 0, opacity: 1 },
+      '-=0.6'
+    )
+  }
 
-  tl.fromTo(heroDescRef.value, 
-    { y: 15, opacity: 0 },
-    { y: 0, opacity: 0.7 },
-    '-=0.6'
-  )
+  if (heroDescRef.value) {
+    tl.fromTo(heroDescRef.value, 
+      { y: 15, opacity: 0 },
+      { y: 0, opacity: 0.7 },
+      '-=0.6'
+    )
+  }
 
   tl.fromTo('.hero-actions', 
     { y: 10, opacity: 0 },


### PR DESCRIPTION
修复 GSAP 动画目标未找到的问题

- 修复 `BlogSection.vue` 中 `.blog-reveal` 目标不存在的问题，为每个博客卡片添加对应的 CSS 类。
- 修复 `index.vue` 中 GSAP 在 `heroTitleRef` 尚未初始化时执行导致的空目标错误。
- 为 `gsap.fromTo(heroTitleRef.value, ...)` 添加 `if (heroTitleRef.value)` 判断，确保元素存在后再执行动画。